### PR TITLE
Allow passing dict containing a JSON schema

### DIFF
--- a/jsonschema_typed/plugin.py
+++ b/jsonschema_typed/plugin.py
@@ -528,9 +528,11 @@ class JSONSchemaPlugin(Plugin):
                 if not ctx.type.args:
                     return ctx.type
                 schema_path, *key_path = list(map(self.resolve_var, ctx.type.args))
-
-                schema_path = os.path.abspath(schema_path)
-                schema = self._load_schema(schema_path)
+                if isinstance(schema_path, dict):
+                    schema = schema_path
+                else:
+                    schema_path = os.path.abspath(schema_path)
+                    schema = self._load_schema(schema_path)
 
                 if key_path:
                     schema = self.make_subschema(schema, key_path)


### PR DESCRIPTION
In my application, we need to pass a dictionary defining a JSON schema instead of a file location, like this:

```python
v: JSONSchema['var:mymodule.myschema:mySchema']
```

This is useful when the schema is already parsed, or if it is stored in a Python file (e.g. for translation).

This solution is very hacky and I think overlaps with #2 . I'm submitting this PR as part of the repo migration, not because I think this is the way this should be done.